### PR TITLE
feat: support 2-point vertices

### DIFF
--- a/forcer/recognition.h
+++ b/forcer/recognition.h
@@ -74,6 +74,9 @@ Drop `PREFIX'notation;
 	#write "Error: call loadTopopologies first."
 #endif
 
+* remove 2-point vertices
+id vx(p1?,p2?) = replace_(p1,-p2);
+
 * remove signs from topologies to be matched
 Multiply acc(1);
 repeat id vx(?a) = v(?a)*acc(vx(?a));


### PR DESCRIPTION
The current Forcer doesn't work with 2-point vertices like `vx(p1,p2)`. Example:
```form
#include- forcer.h

L F1 = vx(Q,p1,p3)*vx(-p1,p2)*vx(-Q,-p2,-p3)/p1.p1/p2.p2/p3.p3;
L F2 = vx(Q,p1,p2)*vx(-Q,-p1,-p2)/p1.p1^2/p2.p2;

#call Forcer()
P;
.end
```
Forcer can't recognize `F1` can be reduced to the one-loop bubble topology and gives the same result as `F2`.

This patch tries to fix it, hopefully without any side effects.